### PR TITLE
Get the real flutter path if 'flutterPath' is a symbolic link path

### DIFF
--- a/bin/flutter_cors.dart
+++ b/bin/flutter_cors.dart
@@ -90,7 +90,10 @@ Future<String> getFlutterFolderPath(ArgResults args) async {
     flutterPath = whichFlutterResult.stdout as String;
   }
 
-  return File(flutterPath.trim()).parent.parent.path;
+  // Get the real flutter path if 'flutterPath' is a symbolic link path.
+  final realFlutterPath = File(flutterPath.trim()).resolveSymbolicLinksSync();
+
+  return File(realFlutterPath).parent.parent.path;
 }
 
 // Delete flutter/bin/cache/flutter_tools.stamp


### PR DESCRIPTION
If we install Flutter by Homebrew or other pakcage manager, we will a symbolic link path.

```shell
$ which flutter
/opt/homebrew/bin/flutter

$ ls -l /opt/homebrew/bin/flutter
/opt/homebrew/bin/flutter -> /opt/homebrew/Caskroom/flutter/3.7.7/flutter/bin/flutter
```

We maybe should get the original flutter path to find the chrome dart file.